### PR TITLE
Update admin-lte vendor to stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "yiisoft/yii2": "*",
         "yiisoft/yii2-bootstrap": "*",
         "cebe/yii2-gravatar": "*",
-        "bower-asset/admin-lte": "@stable",
+        "bower-asset/admin-lte": "1.3.*",
         "bower-asset/font-awesome": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "yiisoft/yii2": "*",
         "yiisoft/yii2-bootstrap": "*",
         "cebe/yii2-gravatar": "*",
-        "bower-asset/admin-lte": "*",
+        "bower-asset/admin-lte": "@stable",
         "bower-asset/font-awesome": "*"
     },
     "autoload": {


### PR DESCRIPTION
Now composer require `*` then equivalently `1.2.1 - dev-bower` .
It should be `1.3.1` - current stable version. 
Need to fix some bugs.