### PR TITLE
Different structure of adminLTE with     "minimum-stability" : "dev"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "yiisoft/yii2": "*",
         "yiisoft/yii2-bootstrap": "*",
         "cebe/yii2-gravatar": "*",
-        "bower-asset/admin-lte": "*",
+        "bower-asset/admin-lte": "~1.3",
         "bower-asset/font-awesome": "*"
     },
     "autoload": {


### PR DESCRIPTION
I installed yii2 like documentation recommended
```
php composer.phar global require "fxp/composer-asset-plugin:1.0.0"
php composer.phar create-project --prefer-dist --stability=dev yiisoft/yii2-app-basic basic
```
And try to install yii2-adminlte-asset
```
php composer.phar require dmstr/yii2-adminlte-asset "*"
```

Then composer install https://github.com/almasaeed2010/AdminLTE from master branch (cause --stability=dev)
Here is the problem. AdminLTE(master) installed "as is", without bower.json and have  different structure from release. Css/js patch are wrong.
So, I think you should set AdminLTE version or set minimum-stability in composer.json
