### PR TITLE
Icon Placement before message

### DIFF
--- a/widgets/Alert.php
+++ b/widgets/Alert.php
@@ -86,7 +86,7 @@ class Alert extends Widget
                     $this->options['id'] = $this->getId() . '-' . $type;
 
                     echo BootstrapAlert::widget([
-                            'body' => $message . $this->alertTypes[$type]['icon'],
+                            'body' => $this->alertTypes[$type]['icon'] . $message,
                             'closeButton' => $this->closeButton,
                             'options' => $this->options,
                         ]);


### PR DESCRIPTION
Without changes, I am getting below flashes. (note the place of icon)
![image](https://cloud.githubusercontent.com/assets/8522676/7100351/aa2249ec-e036-11e4-86da-c2361682e583.png)

After this change, its fixed.