### PR TITLE
Changing to headers

### DIFF
--- a/example-views/yiisoft/yii2-app/layouts/main.php
+++ b/example-views/yiisoft/yii2-app/layouts/main.php
@@ -27,7 +27,7 @@ if (Yii::$app->controller->action->id === 'login') {
         <meta charset="<?= Yii::$app->charset ?>"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <?= Html::csrfMetaTags() ?>
-        <title><?= Html::encode($this->title) ?></title>
+        <title><?= strip_tags($this->title) ?></title>
         <?php $this->head() ?>
     </head>
     <body class="skin-blue">


### PR DESCRIPTION
It allows to use headers as in adminLte

```php
$this->title = 'About <small>multiple types of charts</small>';
```

![image](https://cloud.githubusercontent.com/assets/874234/7551128/ef1ef0d0-f685-11e4-8fb3-6b755f374c01.png)

@schmunk42
It seems it does not break the security. If so, then merge.